### PR TITLE
Making efficient metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ def metrics():
         logger=logger,
     ).get_auth_header()
     headers["Authorization"] = auth_value
-    print(api_user)
+
     # check endpoint
     PrefectHealthz(
         url=url, headers=headers, max_retries=max_retries, logger=logger
@@ -75,15 +75,15 @@ def metrics():
         pagination_limit=pagination_limit,
         target_metrics=target_metrics,
     )
-    print("Init Metrics")
+
     # Register the metrics with Prometheus
     logger.info("Initializing metrics...")
     REGISTRY.register(metrics)
-    print("Start Listening")
+
     # Start the HTTP server to expose Prometheus metrics
     start_http_server(metrics_port)
     logger.info("Exporter listening on port :%i", metrics_port)
-    print("Listening")
+
     # Run the loop to collect Prefect metrics
     while True:
         time.sleep(5)

--- a/metrics/calculator.py
+++ b/metrics/calculator.py
@@ -21,6 +21,7 @@ class MetricCalculator:
         metric: Metric,
         start_timestamp: datetime = datetime(1970, 1, 1, tzinfo=timezone.utc),
         end_timestamp: datetime = datetime.now(timezone.utc),
+        source="all_flow_runs",
     ) -> None:
         """
         Aggregation of flow runs segmented by state.
@@ -31,7 +32,7 @@ class MetricCalculator:
             end_timestamp(Datetime): Represents the end of the flow run timestamps that will be included
         """
 
-        all_flow_runs = self.data.get("all_flow_runs")
+        flow_runs = self.data.get(source)
 
         state_total = {
             "Failed": 0,
@@ -44,7 +45,7 @@ class MetricCalculator:
             "Late": 0,
         }
 
-        for flow_run in all_flow_runs:
+        for flow_run in flow_runs:
             state = flow_run["state"]["name"]
             timestamp = datetime.strptime(
                 flow_run["state"]["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z"

--- a/metrics/data_calculation_mappings.json
+++ b/metrics/data_calculation_mappings.json
@@ -11,7 +11,8 @@
             "prefect_work_pools_total",
             "prefect_work_queues_total",
             "prefect_flow_run_state_total",
-            "prefect_flow_run_state_past_24_hours"
+            "prefect_flow_run_state_past_24_hours",
+            "prefect_flow_run_state_past_offset_minutes"
         ],
         "data_sources_needed": ["deployments", "flows", "work_pools", "work_queues", "all_flow_runs"]
     },
@@ -23,6 +24,22 @@
             "prefect_info_flow_runs",
             "prefect_info_work_pools",
             "prefect_info_work_queues"
+        ],
+        "data_sources_needed": ["deployments", "flows", "flow_runs", "work_pools", "work_queues", "all_flow_runs"]
+    },
+    "legacy_metrics": {
+        "metrics_to_collect": [
+            "prefect_info_deployments",
+            "prefect_deployments_total",
+            "prefect_info_flows",
+            "prefect_info_flow_runs",
+            "prefect_flows_total",
+            "prefect_flow_runs_total",
+            "prefect_info_work_pools",
+            "prefect_work_pools_total",
+            "prefect_info_work_queues",
+            "prefect_work_queues_total",
+            "prefect_flow_runs_total_run_time"
         ],
         "data_sources_needed": ["deployments", "flows", "flow_runs", "work_pools", "work_queues", "all_flow_runs"]
     },
@@ -54,28 +71,32 @@
         "metrics_to_collect": ["prefect_flow_run_state_past_24_hours"],
         "data_sources_needed": ["all_flow_runs"]
     },
-    "": {
+    "prefect_info_deployments": {
         "metrics_to_collect": ["prefect_info_deployments"],
         "data_sources_needed": ["deployments", "flows"]
     },
-    "": {
+    "prefect_info_flows": {
         "metrics_to_collect": ["prefect_info_flows"],
         "data_sources_needed": ["flows"]
     },
-    "": {
+    "prefect_flow_runs_total_run_time": {
         "metrics_to_collect": ["prefect_flow_runs_total_run_time"],
         "data_sources_needed": ["flows", "all_flow_runs"]
     },
-    "": {
+    "prefect_info_flow_runs": {
         "metrics_to_collect": ["prefect_info_flow_runs"],
         "data_sources_needed": ["deployments", "flows", "flow_runs"]
     },
-    "": {
+    "prefect_info_work_pools": {
         "metrics_to_collect": ["prefect_info_work_pools"],
         "data_sources_needed": ["work_pools"]
     },
-    "": {
+    "prefect_info_work_queues": {
         "metrics_to_collect": ["prefect_info_work_queues"],
         "data_sources_needed": ["work_queues"]
+    },
+    "prefect_flow_run_state_past_offset_minutes": {
+        "metrics_to_collect": ["prefect_flow_run_state_past_offset_minutes"],
+        "data_sources_needed": ["flow_runs"]
     }
 }

--- a/metrics/data_sourcer.py
+++ b/metrics/data_sourcer.py
@@ -1,5 +1,3 @@
-import time
-
 from metrics.deployments import PrefectDeployments
 from metrics.flow_runs import PrefectFlowRuns
 from metrics.flows import PrefectFlows
@@ -61,7 +59,6 @@ class DataSourcer:
         """
         Fetch deployment data
         """
-        start = time.time()
         deployments = PrefectDeployments(
             self.url,
             self.headers,
@@ -70,14 +67,12 @@ class DataSourcer:
             self.enable_pagination,
             self.pagination_limit,
         ).get_deployments_info()
-        print(f"Deployments fetch in seconds: {time.time()-start}")
         return deployments
 
     def get_flows(self):
         """
         Fetch flow data
         """
-        start = time.time()
         flows = PrefectFlows(
             self.url,
             self.headers,
@@ -86,14 +81,12 @@ class DataSourcer:
             self.enable_pagination,
             self.pagination_limit,
         ).get_flows_info()
-        print(f"Flows fetch in seconds: {time.time()-start}")
         return flows
 
     def get_flow_runs(self):
         """
         Fetch flow run data in the legacy manner
         """
-        start = time.time()
         flow_runs = PrefectFlowRuns(
             self.url,
             self.headers,
@@ -103,14 +96,12 @@ class DataSourcer:
             self.enable_pagination,
             self.pagination_limit,
         ).get_flow_runs_info()
-        print(f"Flow Runs fetch in seconds: {time.time()-start}")
         return flow_runs
 
     def get_all_flow_runs(self):
         """
         Fetch all flow run from the entire history of the given prefect instance
         """
-        start = time.time()
         all_flow_runs = PrefectFlowRuns(
             self.url,
             self.headers,
@@ -120,14 +111,12 @@ class DataSourcer:
             self.enable_pagination,
             self.pagination_limit,
         ).get_all_flow_runs_info()
-        print(f"All Flow Runs fetch in seconds: {time.time()-start}")
         return all_flow_runs
 
     def get_work_pools(self):
         """
         Fetch work pool data
         """
-        start = time.time()
         work_pools = PrefectWorkPools(
             self.url,
             self.headers,
@@ -136,14 +125,12 @@ class DataSourcer:
             self.enable_pagination,
             self.pagination_limit,
         ).get_work_pools_info()
-        print(f"Work Pools fetch in seconds: {time.time()-start}")
         return work_pools
 
     def get_work_queues(self):
         """
         Fetch work queue data
         """
-        start = time.time()
         work_queues = PrefectWorkQueues(
             self.url,
             self.headers,
@@ -152,5 +139,4 @@ class DataSourcer:
             self.enable_pagination,
             self.pagination_limit,
         ).get_work_queues_info()
-        print(f"Work Queues fetch in seconds: {time.time()-start}")
         return work_queues

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -55,8 +55,16 @@ class PrefectMetrics(object):
         self.target_metrics = target_metrics
         self.data = {}
         self.calculator = None
-        self.metrics_to_collect = []
-        self.data_sources = []
+
+        ##
+        # Get lists data sources to fetch and metrics to load
+        #
+        (
+            self.metrics_to_collect,
+            self.data_sources,
+        ) = self.get_data_calculation_mappings()
+        self.logger.info("Metrics to Collect: %s", str(self.metrics_to_collect))
+        self.logger.info("Data Sources: %s", str(self.data_sources))
 
     def collect(self) -> Metric:
         """
@@ -87,16 +95,6 @@ class PrefectMetrics(object):
             self.logger.info("Pagination is disabled")
 
         ##
-        # Get data sources to fetch and metrics to load
-        #
-        (
-            self.metrics_to_collect,
-            self.data_sources,
-        ) = self.get_data_calculation_mappings()
-        print(self.metrics_to_collect)
-        print(self.data_sources)
-
-        ##
         # Get Prefect resources based on required data sources
         #
         sourcer = DataSourcer(
@@ -109,7 +107,9 @@ class PrefectMetrics(object):
             offset_minutes=self.offset_minutes,
         )
         for source in self.data_sources:
+            start = time.time()
             fetch_source_data = sourcer.get_sourcing_method(source)
+            self.logger.info("%s fetch in second: %d", source, (time.time() - start))
             self.data[source] = fetch_source_data()
 
         ##

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -115,7 +115,10 @@ class PrefectMetrics(object):
         ##
         # Build and output metrics to the prometheus client
         #
-        builder = MetricBuilder(data=self.data)
+        builder = MetricBuilder(
+            data=self.data,
+            offset_minutes=self.offset_minutes,
+        )
         for metric in self.metrics_to_collect:
             build_metrics_output = builder.get_builder_method(metric)
             for metric in build_metrics_output():


### PR DESCRIPTION
Change Log:
- Removed print statements and added logging to measure data source fetch time
- Added logging to indicate data sources needed and metrics being collected. 
- Moved `get_data_calculation_mappings()` to init statement as it only needs to execute once
- Created a new metric to calculate flow run states counts based off of the `OFFSET_MINUTES` env variable. This is to enable lower latency in environments with high quantities of flow runs.